### PR TITLE
Make core/with-start accept multiple bindings

### DIFF
--- a/src/peripheral/core.clj
+++ b/src/peripheral/core.clj
@@ -30,7 +30,10 @@
 (defmacro with-start
   "Start the given component, binding the started component to the given form,
    ensuring the shutdown of the component after the body has been executed."
-  [[form component] & body]
+  [[form component & more] & body]
   `(with-start*
      ~component
-     (fn [~form] ~@body)))
+     (fn [~form]
+       ~(if (seq more)
+          (list* `with-start more body)
+          (list* `do body)))))

--- a/test/peripheral/core_test.clj
+++ b/test/peripheral/core_test.clj
@@ -2,16 +2,22 @@
   (:require [midje.sweet :refer :all]
             [peripheral.core :refer :all]))
 
-(defcomponent Test [data-atom]
+(defcomponent Test [data-atom value]
   :peripheral/started (fn [this]
-                        (reset! data-atom "started")
+                        (reset! data-atom [:started value])
                         this)
   :peripheral/stopped (fn [this]
-                        (reset! data-atom "stopped")
+                        (reset! data-atom [:stopped value])
                         this))
 
 (fact "about 'with-start'"
       (let [x (atom nil)]
-        (with-start [started (Test. x)]
-          @x => "started")
-        @x => "stopped"))
+        (with-start [started (Test. x nil)]
+          @x => [:started nil])
+        @x => [:stopped nil])
+      (let [parent-atom (atom nil)
+            child-atom (atom nil)]
+        (with-start [parent (Test. parent-atom nil)
+                     child (Test. child-atom parent)]
+          @parent-atom => [:started nil]
+          @child-atom  => [:started parent])))


### PR DESCRIPTION
This patch allows starting and stopping multiple components using
a single with-start block. Each binding can be used by subsequently
started components in a let-like fashion.
